### PR TITLE
Fix broken external link targets and header typo

### DIFF
--- a/andrew-computer-sub.html
+++ b/andrew-computer-sub.html
@@ -8,8 +8,8 @@
 </head>
 <body>
 
-  <h3>Hey dude!</h1>
-    <p>Thanks for working with me to set this up. You will be charged $15 every month for 16 months ($240) to cover the remaining balance of the comupter.</p>
+  <h3>Hey dude!</h3>
+    <p>Thanks for working with me to set this up. You will be charged $15 every month for 16 months ($240) to cover the remaining balance of the computer.</p>
   <!-- <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
     <input type="hidden" name="cmd" value="_s-xclick">
     <input type="hidden" name="hosted_button_id" value="LDRX5DBHQRMPA">

--- a/index.html
+++ b/index.html
@@ -512,10 +512,10 @@ print 'It took ' + i + ' iterations to sort the deck.';</code></pre>
 			<footer id="footer">
 				<div class="inner">
 					<ul class="icons">
-						<li><a href="https://twitter.com/benjaminspak" target="_blanks" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
-						<li><a href="https://github.com/benjaminspak" target="_blanks" class="icon fa-github"><span class="label">Github</span></a></li>
-						<li><a href="https://linkedin.com/in/benjaminspak" target="_blanks" class="icon fa-linkedin"><span class="label">LinkedIn</span></a></li>
-						<li><a href="https://www.youtube.com/c/benjaminspak" target="_blanks" class="icon fa-youtube"><span class="label">Youtube</span></a></li>
+						<li><a href="https://twitter.com/benjaminspak" target="_blank" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
+						<li><a href="https://github.com/benjaminspak" target="_blank" class="icon fa-github"><span class="label">Github</span></a></li>
+						<li><a href="https://linkedin.com/in/benjaminspak" target="_blank" class="icon fa-linkedin"><span class="label">LinkedIn</span></a></li>
+						<li><a href="https://www.youtube.com/c/benjaminspak" target="_blank" class="icon fa-youtube"><span class="label">Youtube</span></a></li>
 						<!-- <li><a href="#" class="icon fa-envelope-o"><span class="label">Email</span></a></li>-->
 					</ul>
 					<ul class="copyright">


### PR DESCRIPTION
## Summary
- fix incorrect `target` attribute on social media links
- correct header closing tag and typo in subscription page

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684204066df88320ac15e645cab94558